### PR TITLE
Fix errors and warnings at compile time, pin versions, add readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+
+docs/build/*

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-x
+# docs for UShER
+
+## compiling locally
+1. `pip install -r requirements.txt`
+2. `cd docs`
+3. `make`
+

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Docs will be created in a new folder named `build`, and you can clean up afterwa
 * Currently compiles with `-W`, so warnings become errors
 
 ### common warnings/errors
-* `document isn't included in any toctree` -- "toctree" is the table-of-contents sidebar which appears on the left when the docs are compiled. Add the page in question to index.rst so it can be added to the toctree.
+* `document isn't included in any toctree` -- "toctree" is the table-of-contents sidebar which appears on the left when the docs are compiled. If you want the page in the sidebar, add it to the first :toctree: directive in index.rst. If you don't want it to actually appear in the sidebar, added to the second :hidden: toctree directive in index.rst. Don't delete the blank newline just below :hidden: or things will break.
 * `Title underline too short` -- RST is picky about this, just roll with it
 * `Duplicate explicit target name: "here".` -- [this is another weird RST quirk](https://github.com/sphinx-doc/sphinx/issues/3921), which can be solved by including two underscores instead of one when referencing other pages
 * Some websites (Zendesk-based docs, doi.org, etc) consistently break `linkcheck`, so if you have an external link that you know is working, but it can't pass linkcheck, just add the URL to linkcheck_ignore in conf.py

--- a/README.md
+++ b/README.md
@@ -1,7 +1,23 @@
 # docs for UShER
+Codebase for [the UShER wiki](https://usher-wiki.readthedocs.io/en/latest/).
 
-## compiling locally
+## notes for maintainers of these docs
+### compiling locally
 1. `pip install -r requirements.txt`
 2. `cd docs`
-3. `make`
+3. `make linkcheck`
+4. `make html`
 
+Docs will be created in a new folder named `build`, and you can clean up afterwards with `make clean`.
+
+### tips
+* [RST reference docs](https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html)
+* RST can't really do nested formatting (eg it can do **bold** and *italics* but not ***bold italics***)
+* Add new pages to index.rst to ensure it ends up on the sidebar on the left
+* Currently compiles with `-W`, so warnings become errors
+
+### common warnings/errors
+* `document isn't included in any toctree` -- "toctree" is the table-of-contents sidebar which appears on the left when the docs are compiled. Add the page in question to index.rst so it can be added to the toctree.
+* `Title underline too short` -- RST is picky about this, just roll with it
+* `Duplicate explicit target name: "here".` -- [this is another weird RST quirk](https://github.com/sphinx-doc/sphinx/issues/3921), which can be solved by including two underscores instead of one when referencing other pages
+* Some websites (Zendesk-based docs, doi.org, etc) consistently break `linkcheck`, so if you have an external link that you know is working, but it can't pass linkcheck, just add the URL to linkcheck_ignore in conf.py

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    = -W --keep-going
+SPHINXOPTS    ?=
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?=
+SPHINXOPTS    = -W --keep-going
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -21,7 +21,7 @@ if errorlevel 9009 (
 	echo.may add the Sphinx directory to PATH.
 	echo.
 	echo.If you don't have Sphinx installed, grab it from
-	echo.http://sphinx-doc.org/
+	echo.https://sphinx-doc.org/
 	exit /b 1
 )
 

--- a/docs/source/QuickStart.rst
+++ b/docs/source/QuickStart.rst
@@ -65,7 +65,7 @@ matUtils
 --------------
 
 matUtils is a toolkit for rapid exploratory analysis and manipulation of mutation-annotated trees (MATs).
-The full manual page including detailed parameter information can be found `here <https://usher-wiki.readthedocs.io/en/latest/matUtils.html>`_. matUtils is installed with the UShER package (see above installation instructions using conda).
+The full manual page including detailed parameter information can be found `here <https://usher-wiki.readthedocs.io/en/latest/matUtils.html>`__. matUtils is installed with the UShER package (see above installation instructions using conda).
 
 .. code-block:: sh
 
@@ -87,7 +87,7 @@ These outputs include newick, vcf, other pb, and Augur JSON capable of being vis
 The above command filters samples with higher parsimony scores than 3 and ancestral branches with a greater length than 10, then collects a subtree representing 
 the nearest 100 samples to our indicated sample. From this subtree this command generates a vcf containing all sample mutation information, a newick representing the subtree, and an Auspice-uploadable JSON in mere seconds.
 
-Tutorials for matUtils, including an example workflow, sample placement uncertainty, and phylogeographic analysis, can be found `here <https://usher-wiki.readthedocs.io/en/latest/tutorials.html>`_.
+Tutorials for matUtils, including an example workflow, sample placement uncertainty, and phylogeographic analysis, can be found `here <https://usher-wiki.readthedocs.io/en/latest/tutorials.html>`__.
 
 
 
@@ -96,7 +96,7 @@ matOptimize
 --------------
 
 matOptimize is a program that can optimize the topology of mutation-annotated trees (MATs) using subtree pruning and regrating (SPR) moves for parsimony.
-The full manual page including detailed parameter information can be found `here <https://usher-wiki.readthedocs.io/en/latest/matOptimize.html>`_. matOptimize is installed with the UShER package (see above installation instructions using conda).
+The full manual page including detailed parameter information can be found `here <https://usher-wiki.readthedocs.io/en/latest/matOptimize.html>`__. matOptimize is installed with the UShER package (see above installation instructions using conda).
 
 .. code-block:: sh
 

--- a/docs/source/Strain_Phylogenetics.rst
+++ b/docs/source/Strain_Phylogenetics.rst
@@ -8,7 +8,7 @@ Strain_Phylogenetics
 RotTrees
 ----------
 
-RotTrees enables quick inference of congruence of tanglegrams. This is particularly useful for SARS-CoV-2 phylogenomics due to multiple groups independently analyzing data-sets with many identical samples. Previous tanglegram visualization software, such as `cophylo <ttps://www.rdocumentation.org/packages/phytools/versions/0.7-20/topics/cophylo>`_ and `Dendroscope3 <http://dendroscope.org/>`_ rely on fewer rotations to minimize crossings over, which is inadequate for phylogenies on the scale of SARS-CoV-2. We implemented a quick heuristic to produce vastly improved tanglegrams.
+RotTrees enables quick inference of congruence of tanglegrams. This is particularly useful for SARS-CoV-2 phylogenomics due to multiple groups independently analyzing data-sets with many identical samples. Previous tanglegram visualization software, such as `cophylo <ttps://www.rdocumentation.org/packages/phytools/versions/0.7-20/topics/cophylo>`__ and `Dendroscope3 <http://dendroscope.org/>`_ rely on fewer rotations to minimize crossings over, which is inadequate for phylogenies on the scale of SARS-CoV-2. We implemented a quick heuristic to produce vastly improved tanglegrams.
 
 First, ensure that `tree_1.nh` and `tree_2.nh` have identical sets of samples. Then, use as follows:
 

--- a/docs/source/bte.rst
+++ b/docs/source/bte.rst
@@ -40,7 +40,7 @@ Download the latest public SARS-CoV-2 tree:
 
 And proceed directly to your analysis in Python!
 
-.. code-black::
+.. code-block::
 
   import bte
   tree = bte.MATree("public-latest.all.masked.pb.gz")

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,7 +30,7 @@ release = '0.0.2'
 
 # -- General configuration ---------------------------------------------------
 
-# https://github.com/sphinx-doc/sphinx/issues/7369 403 blocks by support.orcid.org
+# https://github.com/sphinx-doc/sphinx/issues/7369
 user_agent = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.45 Safari/537.36'
 
 
@@ -44,11 +44,11 @@ pygments_style = 'sphinx'
 linkcheck_anchors = False
 
 # Put in URLs you want to ignore for linkcheck below. Common problematic URLs include:
-# * doi.org 
+# * doi.org (but only sometimes?)
 # * any docs website that uses ZenDesk
-# * websites with expired certs
+# * websites with weird or expired certs (ex: mlab.wustl.edu)
 # * internal links which are not resolved before compile time (ex: a clickable image with an internal link)
-linkcheck_ignore = [ ] 
+linkcheck_ignore = [ "https://mblab.wustl.edu/GTF22.html" ] 
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
@@ -72,7 +72,8 @@ exclude_patterns = ['build', 'Thumbs.db', '.DS_Store']
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+#html_theme = 'default'
+html_theme = 'sphinx_rtd_theme'
 
 # Note that writing options under "html_theme_options" isn't supported if html_theme is default,
 # so we do it like this instead

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -60,7 +60,8 @@ linkcheck_ignore = [ "https://mblab.wustl.edu/GTF22.html" ]
 source_suffix = '.rst'
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+# This allows us to have RST documents that don't normally appear in the TOC!
+templates_path = ['_templates', 'presentations']
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,8 +1,10 @@
+# -*- coding: utf-8 -*-
+#
 # Configuration file for the Sphinx documentation builder.
 #
-# This file only contains a selection of the most common options. For a full
-# list see the documentation:
-# https://www.sphinx-doc.org/en/master/usage/configuration.html
+# This file does only contain a selection of the most common options. For a
+# full list see the documentation:
+# https://www.sphinx-doc.org/en/master/config
 
 # -- Path setup --------------------------------------------------------------
 
@@ -23,19 +25,39 @@ author = 'Bryan Thornlow'
 
 
 # The full version, including alpha/beta/rc tags
-release = '0.0.1'
+release = '0.0.2'
 
 
 # -- General configuration ---------------------------------------------------
 
+# https://github.com/sphinx-doc/sphinx/issues/7369 403 blocks by support.orcid.org
+user_agent = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.45 Safari/537.36'
+
+
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = [ ]
-
+extensions = [ 'myst_parser' ]
 
 pygments_style = 'sphinx'
 
+linkcheck_anchors = False
+
+# Put in URLs you want to ignore for linkcheck below. Common problematic URLs include:
+# * doi.org 
+# * any docs website that uses ZenDesk
+# * websites with expired certs
+# * internal links which are not resolved before compile time (ex: a clickable image with an internal link)
+#linkcheck_ignore = [ ] 
+
+# The suffix(es) of source filenames.
+# You can specify multiple suffix as a list of string:
+#
+# source_suffix = ['.rst', '.md']
+#
+# Note that if you have the myst_parser extension, .md files we will
+# be rendered too, even though they are not listed below!
+source_suffix = '.rst'
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -43,7 +65,7 @@ templates_path = ['_templates']
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = []
+exclude_patterns = ['build', 'Thumbs.db', '.DS_Store']
 
 
 # -- Options for HTML output -------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -37,7 +37,7 @@ user_agent = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Ge
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = [ 'myst_parser' ]
+extensions = [ ]
 
 pygments_style = 'sphinx'
 
@@ -48,7 +48,7 @@ linkcheck_anchors = False
 # * any docs website that uses ZenDesk
 # * websites with expired certs
 # * internal links which are not resolved before compile time (ex: a clickable image with an internal link)
-#linkcheck_ignore = [ ] 
+linkcheck_ignore = [ ] 
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
@@ -72,13 +72,14 @@ exclude_patterns = ['build', 'Thumbs.db', '.DS_Store']
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-#
 html_theme = 'default'
+
+# Note that writing options under "html_theme_options" isn't supported if html_theme is default,
+# so we do it like this instead
 style_nav_header_background = 'white'
 logo_only = True
 display_version = False
 include_hidden = True
-html_theme_options = {'logo_only':True, 'display_version':False, 'include_hidden':True}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -14,6 +14,14 @@ Welcome to the manual for UShER package, that includes SARS-CoV-2 Phylogenetics 
    bte.rst
    tutorials.rst
 
+.. toctree::
+    :hidden:
+    
+    covid-meet.rst
+    ismb.rst
+    sp_meet.rst
+    Strain_Phylogenetics.rst
+
 .. _UShER:
 
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,6 +5,8 @@ UShER Wiki
 Welcome to the manual for UShER package, that includes SARS-CoV-2 Phylogenetics tools UShER, matUtils, matOptimize, RIPPLES, strain_phylogenetics, and others. Please see the table of contents below or on the sidebar, or `click here <https://usher-wiki.readthedocs.io/en/latest/QuickStart.html>`_ for a quick tutorial on getting started.
 
 .. toctree::
+   :hidden:
+   
    QuickStart.rst
    Installation.rst
    UShER.rst
@@ -13,14 +15,6 @@ Welcome to the manual for UShER package, that includes SARS-CoV-2 Phylogenetics 
    ripples.rst
    bte.rst
    tutorials.rst
-
-.. toctree::
-    :hidden:
-    
-    covid-meet.rst
-    ismb.rst
-    sp_meet.rst
-    Strain_Phylogenetics.rst
 
 .. _UShER:
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -24,7 +24,7 @@ UShER
     :width: 500px
     :align: center
 
-UShER is a program for rapid, accurate placement of samples to existing phylogenies. Information on installation, usage, and features can be found `here <https://usher-wiki.readthedocs.io/en/latest/UShER.html>`_. Our manuscript about UShER can be found `here <https://www.nature.com/articles/s41588-021-00862-7>`_.
+UShER is a program for rapid, accurate placement of samples to existing phylogenies. Information on installation, usage, and features can be found `here <https://usher-wiki.readthedocs.io/en/latest/UShER.html>`__. Our manuscript about UShER can be found `here <https://www.nature.com/articles/s41588-021-00862-7>`_.
 
 
 .. _matUtils:
@@ -33,23 +33,23 @@ UShER is a program for rapid, accurate placement of samples to existing phylogen
 matUtils
 ============
 
-matUtils is a toolkit for querying, interpreting and manipulating the mutation-annotated trees (MATs). Information on its usage can be found `here <https://usher-wiki.readthedocs.io/en/latest/matUtils.html>`_.
+matUtils is a toolkit for querying, interpreting and manipulating the mutation-annotated trees (MATs). Information on its usage can be found `here <https://usher-wiki.readthedocs.io/en/latest/matUtils.html>`__.
 
 
 
 matOptimize
 ============
 
-matOptimize is a program to rapidly and effectively optimize a mutation-annotated tree (MAT) for parsimony using subtree pruning and regrafting (SPR) moves within a user-defined radius. Information on its usage can be found `here <https://usher-wiki.readthedocs.io/en/latest/matOptimize.html>`_.
+matOptimize is a program to rapidly and effectively optimize a mutation-annotated tree (MAT) for parsimony using subtree pruning and regrafting (SPR) moves within a user-defined radius. Information on its usage can be found `here <https://usher-wiki.readthedocs.io/en/latest/matOptimize.html>`__.
 
 
 RIPPLES
 ============
 
-RIPPLES is a program that uses a phylogenomic technique to rapidly and sensitively detect recombinant nodes and their ancestors in a mutation-annotated tree (MAT). Information on its usage can be found `here <https://usher-wiki.readthedocs.io/en/latest/ripples.html>`_.
+RIPPLES is a program that uses a phylogenomic technique to rapidly and sensitively detect recombinant nodes and their ancestors in a mutation-annotated tree (MAT). Information on its usage can be found `here <https://usher-wiki.readthedocs.io/en/latest/ripples.html>`__.
 
 
 BTE
 ============
 
-BTE is a separately packaged Cython API that wraps the highly optimized library underlying these other tools, exposing them for use in Python. Information about its usage can be found `here <https://usher-wiki.readthedocs.io/en/latest/bte.html>`_ and at its `repository <https://github.com/jmcbroome/BTE>`_.
+BTE is a separately packaged Cython API that wraps the highly optimized library underlying these other tools, exposing them for use in Python. Information about its usage can be found `here <https://usher-wiki.readthedocs.io/en/latest/bte.html>`__ and at its `repository <https://github.com/jmcbroome/BTE>`_.

--- a/docs/source/matUtils.rst
+++ b/docs/source/matUtils.rst
@@ -4,7 +4,7 @@
 matUtils
 ***************
 
-matUtils is a suite of tools used to analyze, edit, and manipulate mutation annotated tree (.pb) files, such as the ones shared in our public SARS-CoV-2 MAT database (http://hgdownload.soe.ucsc.edu/goldenPath/wuhCor1/UShER_SARS-CoV-2/) or those constructed via UShER (read `this <https://usher-wiki.readthedocs.io/en/latest/UShER.html#converting-raw-sequences-into-vcf-for-usher-input>`_ and `this <https://usher-wiki.readthedocs.io/en/latest/UShER.html#pre-processing-global-phylogeny>`_ for steps to construct a MAT from an input phylogeny and an alignment). 
+matUtils is a suite of tools used to analyze, edit, and manipulate mutation annotated tree (.pb) files, such as the ones shared in our public SARS-CoV-2 MAT database (http://hgdownload.soe.ucsc.edu/goldenPath/wuhCor1/UShER_SARS-CoV-2/) or those constructed via UShER (read `this <https://usher-wiki.readthedocs.io/en/latest/UShER.html#converting-raw-sequences-into-vcf-for-usher-input>`__ and `this <https://usher-wiki.readthedocs.io/en/latest/UShER.html#pre-processing-global-phylogeny>`__ for steps to construct a MAT from an input phylogeny and an alignment). 
 
 .. _protobuf:
 
@@ -63,9 +63,9 @@ performs phylogenetically informed annotation of amino acid mutations.
 The user provides as input a protobuf file, a GTF file containing gene annotations, and a FASTA reference sequence.
 
 .. note:: 
-    The input GTF must follow the conventions specified `here <https://mblab.wustl.edu/GTF22.html>`_.
+    The input GTF must follow the conventions specified `here <https://mblab.wustl.edu/GTF22.html>`__.
     If multiple ``CDS`` features are associated with a single ``gene_id``,
-    they must be ordered by start position. An example GTF for SARS-CoV-2 can be found `here <http://hgdownload.soe.ucsc.edu/goldenPath/wuhCor1/bigZips/genes/ncbiGenes.gtf.gz>`_.
+    they must be ordered by start position. An example GTF for SARS-CoV-2 can be found `here <http://hgdownload.soe.ucsc.edu/goldenPath/wuhCor1/bigZips/genes/ncbiGenes.gtf.gz>`__.
 
 The output format is a TSV file with four columns, with one line per node (only including nodes with mutations), e.g.
 

--- a/docs/source/matUtils.rst
+++ b/docs/source/matUtils.rst
@@ -91,7 +91,7 @@ the affected codons are listed sequentially, and the nucleotide mutation is repe
 
 **RoHo score**
 
-Additionally, `matUtils summary` can quickly calculate the RoHo score and related values described in `van Dorp et al 2020 <10.1038/s41467-020-19818-2>`_.
+Additionally, `matUtils summary` can quickly calculate the RoHo score and related values described in `van Dorp et al 2020 <https://doi.org/10.1038/s41467-020-19818-2>`_.
 Briefly, the RoHo or Ratio of Homoplasic Offspring is the ratio of the number of descendents in sister clades with or without a specific mutation over the occurrence of 
 all mutations; homoplasic and positively-selected mutations will recur with increased descendent clade sizes at each occurrence. This can be used to quickly
 and conservatively scan for variants of concern. A full explanation of our implementation and tutorial can be found :ref:`here.<roho-tutorial>`

--- a/docs/source/ripples.rst
+++ b/docs/source/ripples.rst
@@ -6,9 +6,9 @@ RIPPLES
 
 RIPPLES (Recombination Inference using Phylogenetic PLacEmentS) is a program used to detect recombination events in large mutation annotated tree (MAT) files.
 
-----------
+-------------
 Installation
-----------
+-------------
 
 To install RIPPLES, simply follow the directions for `installing UShER <https://usher-wiki.readthedocs.io/en/latest/Installation.html>`_, and RIPPLES will be included in your installation.
 

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -267,7 +267,7 @@ Example Introduce Workflow
 In this example we will infer and investigate introductions of SARS-CoV-2 into Spain using public information
 on the command line and visualize an example introduction of interest with Auspice.
 
-Before beginning, download the example protobuf file `public-2021-04-20.all.masked.nextclade.pangolin.pb <https://hgwdev.gi.ucsc.edu/~angie/UShER_SARS-CoV-2/2021/03/02/public-2021-04-20.all.masked.nextclade.pangolin.pb>`_ 
+Before beginning, download the example protobuf file `public-2021-04-20.all.masked.nextclade.pangolin.pb <https://hgwdev.gi.ucsc.edu/~angie/UShER_SARS-CoV-2/2021/03/02/public-2021-03-02.all.masked.nextclade.pangolin.pb>`_ 
 
 We need a region to analyze; in this example, we are going to use Spain, as it has a few hundred associated samples in the public data
 and is a solid representative example. We need to generate the two-column tab-separated file we use as input to `matUtils introduce`.

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -434,7 +434,7 @@ In this workflow, we will output amino acid mutations at each node of a protobuf
 Download the example protobuf file (:download:`translate_example.pb <./translate_example.pb>`), GTF file (:download:`ncbiGenes.gtf <./ncbiGenes.gtf>`), and reference FASTA (`NC_045512v2.fa <https://raw.githubusercontent.com/yatisht/usher/5e83b71829dbe54a37af845fd23d473a8f67b839/test/NC_045512v2.fa>`_).
 
 .. note:: 
-    The input GTF must follow the conventions specified `here <https://mblab.wustl.edu/GTF22.html>`_.
+    The input GTF must follow the conventions specified `here <https://mblab.wustl.edu/GTF22.html>`__.
     If multiple ``CDS`` features are associated with a single ``gene_id``,
     they must be ordered by start position.
 
@@ -527,7 +527,7 @@ The resulting JSON file can now be loaded into Nextstrain / Auspice. Here is the
     :width: 1500px
     :align: center
 
-View the expected JSON in Nextstrain `here <https://nextstrain.org/fetch/raw.githubusercontent.com/bpt26/usher_wiki/main/docs/source/aa_annotated.json?branchLabel=aa_mutations&c=aa_mutations>`_.
+View the expected JSON in Nextstrain `here <https://nextstrain.org/fetch/raw.githubusercontent.com/bpt26/usher_wiki/main/docs/source/aa_annotated.json?branchLabel=aa_mutations&c=aa_mutations>`__.
 
 You can use the ``Branch Labels`` menu in the sidebar to view the annotations.
 
@@ -545,10 +545,10 @@ We also include a `snakemake <https://snakemake.readthedocs.io/en/stable/getting
 .. _protobuf-tutorial:
 
 Interacting Directly with Protobuf Files in Python [ADVANCED USERS]
------------------------------------------------------------
+--------------------------------------------------------------------
 
 Advanced users may desire to interface directly with the protobuf. The following is a brief tutorial on doing so.
-Google's general tutorial on interacting with protobuf in python can be found `here <https://developers.google.com/protocol-buffers/docs/pythontutorial#compiling-your-protocol-buffers>`_.
+Google's general tutorial on interacting with protobuf in python can be found `here <https://developers.google.com/protocol-buffers/docs/pythontutorial#compiling-your-protocol-buffers>`__.
 The instructions here can be applied to a number of additional languages supported by google as well, such as java, PHP, and ruby.
 
 Note that this tutorial is specifically for directly manipulating the MAT protobuf file itself in Python; 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 sphinx==4.4.0
+sphinx_rtd_theme==1.0.0
 attrs==21.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+sphinx==4.4.0
+myst-parser==0.16.1
+sphinx_rtd_theme==1.0.0
+attrs==21.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,2 @@
 sphinx==4.4.0
-myst-parser==0.16.1
-sphinx_rtd_theme==1.0.0
 attrs==21.4.0


### PR DESCRIPTION
General improvements to the documentation website. No actual docs content has been changed, this is just for devs.

**Input needed**
The link to find sister clades results in a 403. 

**Overview**
* Add readme with info on how to compile + common issues
* Add requirements.txt
* Pin a certain version of attrs ([trust me on this one](https://github.com/dockstore/dockstore-documentation/pull/195)), sphinx, and the rtd theme
* Explicitly call the RTD theme, since that's clearly what the website is using
* Add support for excluding certain URLs from linkcheck, ie that dodgy wustl.edu link
* Minor updates to Sphinx's template files

**Warnings/Errors fixed**
* Lots of `duplicate target name` issues
* Underlines too short
* Probable typo in code-block (was code-black, [but probably wasn't intended to be this](https://black.readthedocs.io/en/stable/))
* Several broken links

**Will be done in another PR**
* Add the presentations to a "presentations" folder and mark that as a template folder
  * Doing this will allow us to render the three presentation RSTs without including them in the toctree 
  * Will require rearranging lots of files, hence why that'll be a fresh PR
* Change `SPHINXOPTS` to `-W --keep-going` in order to escalate warnings into errors
  * Will require the presentations fix mentioned above